### PR TITLE
fix: incorrect curl version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends -qq \
     libffi-dev=3.3-6 \
     g++=4:10.2.1-1 \
     git=1:2.30.2-1+deb11u2 \
-    curl=7.74.0-1.3+deb11u10 \
+    curl=7.74.0-1.3+deb11u11 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Previously Dockerfile specified the "7.74.0-1.3+deb11u10" version for curl. With this version package was not built correctly. With the new "7.74.0-1.3+deb11u11" curl version the app builds and starts in the container correctly.