### PR TITLE
[workflow fix] adjusted secret variable naming

### DIFF
--- a/.github/workflows/tests_and_checks.yml
+++ b/.github/workflows/tests_and_checks.yml
@@ -35,7 +35,7 @@ jobs:
         env:
           CONSENSUS_CLIENT_URI: ${{ secrets.CL_API_URL }}
           EXECUTION_CLIENT_URI: ${{ secrets.EXECUTION_API_URL }}
-          LIDO_LOCATOR_ADDRESS: "${{ secrets.LIDO_LOCATOR }}"
+          LIDO_LOCATOR_ADDRESS: "${{ secrets.LIDO_LOCATOR_ADDRESS }}"
           KEYS_API_URI: ${{ secrets.KEYS_API_URL }}
           DRY_RUN: true
 


### PR DESCRIPTION
This renames `LIDO_LOCATOR` secret variable in test&checks workflow to `LIDO_LOCATOR_ADDRESS`, so new PRs could be tested properly.