### PR TITLE
Add support for disabling unexpected exit alerts per module

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ Currently it supports:
 `VALID_WITHDRAWAL_ADDRESSES` - A comma-separated list of addresses. Triggers a critical alert if a monitored execution_request contains a source_address matching any of these addresses 
 * **Required:** false
 * **Default:** []
+---
+`DISABLE_UNEXPECTED_EXIT_ALERTS` - A comma-separated list of module indexes for which unexpected exit alerts are disabled.  
+* **Required:** false
+* **Default:** []
 
 ## Application metrics
 

--- a/src/handlers/exit.py
+++ b/src/handlers/exit.py
@@ -58,6 +58,8 @@ class ExitsHandler(WatcherHandler):
                             owner='other',
                         )
                     )
+        if watcher.disable_unexpected_exit_alerts:
+            exits = [e for e in exits if e.owner == 'user' and str(e.module_index) not in watcher.disable_unexpected_exit_alerts]
         if not exits:
             logger.debug({'msg': f'No exits in block [{head.message.slot}]'})
         else:

--- a/src/variables.py
+++ b/src/variables.py
@@ -45,6 +45,8 @@ LIDO_LOCATOR_ADDRESS = os.getenv('LIDO_LOCATOR_ADDRESS', '')
 
 VALID_WITHDRAWAL_ADDRESSES = [x.lower() for x in os.getenv('VALID_WITHDRAWAL_ADDRESSES', '').split(',') if x]
 
+DISABLE_UNEXPECTED_EXIT_ALERTS=[x.strip() for x in os.getenv('DISABLE_UNEXPECTED_EXITS_ALERTS', '').split(',') if x]
+
 # - Metrics -
 PROMETHEUS_PORT = int(os.getenv('PROMETHEUS_PORT', 9000))
 PROMETHEUS_PREFIX = os.getenv("PROMETHEUS_PREFIX", "ethereum_head_watcher")

--- a/src/watcher.py
+++ b/src/watcher.py
@@ -54,6 +54,7 @@ class Watcher:
         self.indexed_validators_keys: dict[str, str] = {}
         self.chain_reorgs: dict[str, ChainReorgEvent] = {}
         self.handled_headers: list[BlockHeaderResponseData] = []
+        self.disable_unexpected_exit_alerts: list[str] = variables.DISABLE_UNEXPECTED_EXIT_ALERTS
 
     def run(self, slots_range: Optional[str] = SLOTS_RANGE):
         def _run(slot_to_handle='head'):

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -96,3 +96,11 @@ def test_expected_exits(caplog, watcher):
     watcher.run("6833022-6833039")
 
     assert 'Our validators were unexpected exited!' not in caplog.text, "Alert should not be in logs"
+
+
+def test_disabled_alerts_exits(caplog, watcher, monkeypatch):
+    monkeypatch.setattr(watcher, "disable_unexpected_exit_alerts", ['3'])
+
+    watcher.run("11180702-11180703")
+
+    assert 'Our validators were unexpected exited!' not in caplog.text, "Alerts should not be in logs"


### PR DESCRIPTION
Introduced the `DISABLE_UNEXPECTED_EXIT_ALERTS` environment variable, which allows specifying a comma-separated list of module indexes for which unexpected exit alerts should be disabled. 
Updated the alert handling logic to respect this setting.