### PR TITLE
fix: invalid consolidation status alert

### DIFF
--- a/src/handlers/consolidation.py
+++ b/src/handlers/consolidation.py
@@ -256,7 +256,7 @@ class ConsolidationHandler(WatcherHandler):
 
     def _send_invalid_status(self, watcher, slot: str, consolidations: list[InvalidStatusConsolidation]):
         alert = CommonAlert(name="HeadWatcherConsolidationInvalidStatus", severity="critical")
-        summary = "⚠️⚠️⚠️ Attempt to consolidate validators whose status is not active"
+        summary = "⚠️⚠️⚠️ Attempt to consolidate validators in unexpected status (source must be active_exiting, target must be active_ongoing)"
         description = '\n\n'.join(
             self._describe_invalid_status_consolidation(c, watcher.user_keys) for c in consolidations
         )

--- a/src/handlers/consolidation.py
+++ b/src/handlers/consolidation.py
@@ -149,7 +149,7 @@ class ConsolidationHandler(WatcherHandler):
                 )
 
             if (
-                source_validator.status != ValidatorStatus.ACTIVE_ONGOING
+                source_validator.status != ValidatorStatus.ACTIVE_EXITING
                 or target_validator.status != ValidatorStatus.ACTIVE_ONGOING
             ):
                 invalid_status_consolidations.append(

--- a/tests/execution_requests/test_consolidations.py
+++ b/tests/execution_requests/test_consolidations.py
@@ -452,7 +452,7 @@ def test_invalid_source_consolidation_status(
     assert invalid_status_alert is not None
     assert invalid_status_alert.labels.severity == 'critical'
     assert (
-        invalid_status_alert.annotations.summary == "⚠️⚠️⚠️ Attempt to consolidate validators whose status is not active"
+        invalid_status_alert.annotations.summary == "⚠️⚠️⚠️ Attempt to consolidate validators in unexpected status (source must be active_exiting, target must be active_ongoing)"
     )
     assert withdrawal_address in invalid_status_alert.annotations.description
     assert source_validator.index in invalid_status_alert.annotations.description
@@ -554,7 +554,7 @@ def test_invalid_target_consolidation_status(
     assert invalid_status_alert is not None
     assert invalid_status_alert.labels.severity == 'critical'
     assert (
-        invalid_status_alert.annotations.summary == "⚠️⚠️⚠️ Attempt to consolidate validators whose status is not active"
+        invalid_status_alert.annotations.summary == "⚠️⚠️⚠️ Attempt to consolidate validators in unexpected status (source must be active_exiting, target must be active_ongoing)"
     )
     assert withdrawal_address in invalid_status_alert.annotations.description
     assert source_validator.index in invalid_status_alert.annotations.description
@@ -656,7 +656,7 @@ def test_slashed_source_consolidation(
     assert invalid_status_alert is not None
     assert invalid_status_alert.labels.severity == 'critical'
     assert (
-        invalid_status_alert.annotations.summary == "⚠️⚠️⚠️ Attempt to consolidate validators whose status is not active"
+        invalid_status_alert.annotations.summary == "⚠️⚠️⚠️ Attempt to consolidate validators in unexpected status (source must be active_exiting, target must be active_ongoing)"
     )
     assert withdrawal_address in invalid_status_alert.annotations.description
     assert source_validator.index in invalid_status_alert.annotations.description
@@ -758,7 +758,7 @@ def test_slashed_target_consolidation(
     assert invalid_status_alert is not None
     assert invalid_status_alert.labels.severity == 'critical'
     assert (
-        invalid_status_alert.annotations.summary == "⚠️⚠️⚠️ Attempt to consolidate validators whose status is not active"
+        invalid_status_alert.annotations.summary == "⚠️⚠️⚠️ Attempt to consolidate validators in unexpected status (source must be active_exiting, target must be active_ongoing)"
     )
     assert withdrawal_address in invalid_status_alert.annotations.description
     assert source_validator.index in invalid_status_alert.annotations.description
@@ -876,7 +876,7 @@ def test_rejected_consolidation(
     assert block.message.slot in rejected_consolidation_alert.annotations.description
 
 
-def no_rejected_consolidation_alert_for_accepted_consolidations(
+def test_no_rejected_consolidation_alert_for_accepted_consolidations(
     user_validator_1: TestValidator, user_validator_2: TestValidator, watcher: WatcherStub, withdrawal_address: str
 ):
     block = create_sample_block(

--- a/tests/execution_requests/test_consolidations.py
+++ b/tests/execution_requests/test_consolidations.py
@@ -452,7 +452,8 @@ def test_invalid_source_consolidation_status(
     assert invalid_status_alert is not None
     assert invalid_status_alert.labels.severity == 'critical'
     assert (
-        invalid_status_alert.annotations.summary == "⚠️⚠️⚠️ Attempt to consolidate validators in unexpected status (source must be active_exiting, target must be active_ongoing)"
+        invalid_status_alert.annotations.summary
+        == "⚠️⚠️⚠️ Attempt to consolidate validators in unexpected status (source must be active_exiting, target must be active_ongoing)"
     )
     assert withdrawal_address in invalid_status_alert.annotations.description
     assert source_validator.index in invalid_status_alert.annotations.description
@@ -554,7 +555,8 @@ def test_invalid_target_consolidation_status(
     assert invalid_status_alert is not None
     assert invalid_status_alert.labels.severity == 'critical'
     assert (
-        invalid_status_alert.annotations.summary == "⚠️⚠️⚠️ Attempt to consolidate validators in unexpected status (source must be active_exiting, target must be active_ongoing)"
+        invalid_status_alert.annotations.summary
+        == "⚠️⚠️⚠️ Attempt to consolidate validators in unexpected status (source must be active_exiting, target must be active_ongoing)"
     )
     assert withdrawal_address in invalid_status_alert.annotations.description
     assert source_validator.index in invalid_status_alert.annotations.description
@@ -656,7 +658,8 @@ def test_slashed_source_consolidation(
     assert invalid_status_alert is not None
     assert invalid_status_alert.labels.severity == 'critical'
     assert (
-        invalid_status_alert.annotations.summary == "⚠️⚠️⚠️ Attempt to consolidate validators in unexpected status (source must be active_exiting, target must be active_ongoing)"
+        invalid_status_alert.annotations.summary
+        == "⚠️⚠️⚠️ Attempt to consolidate validators in unexpected status (source must be active_exiting, target must be active_ongoing)"
     )
     assert withdrawal_address in invalid_status_alert.annotations.description
     assert source_validator.index in invalid_status_alert.annotations.description
@@ -758,7 +761,8 @@ def test_slashed_target_consolidation(
     assert invalid_status_alert is not None
     assert invalid_status_alert.labels.severity == 'critical'
     assert (
-        invalid_status_alert.annotations.summary == "⚠️⚠️⚠️ Attempt to consolidate validators in unexpected status (source must be active_exiting, target must be active_ongoing)"
+        invalid_status_alert.annotations.summary
+        == "⚠️⚠️⚠️ Attempt to consolidate validators in unexpected status (source must be active_exiting, target must be active_ongoing)"
     )
     assert withdrawal_address in invalid_status_alert.annotations.description
     assert source_validator.index in invalid_status_alert.annotations.description

--- a/tests/execution_requests/test_consolidations.py
+++ b/tests/execution_requests/test_consolidations.py
@@ -294,7 +294,7 @@ def test_over_deposit_consolidation(
     source_validator = Validator(
         index='1',
         balance='1024000000001',
-        status=ValidatorStatus.ACTIVE_ONGOING,
+        status=ValidatorStatus.ACTIVE_EXITING,
         validator=source_validator_state,
     )
 
@@ -374,7 +374,7 @@ def test_over_deposit_consolidation(
     assert rejected_consolidation_alert is None
 
 
-def test_exiting_source_consolidation(
+def test_invalid_source_consolidation_status(
     user_validator_1: TestValidator, user_validator_2: TestValidator, watcher: WatcherStub, withdrawal_address: str
 ):
     block = create_sample_block(
@@ -400,7 +400,7 @@ def test_exiting_source_consolidation(
     source_validator = Validator(
         index='1',
         balance='32000000000',
-        status=ValidatorStatus.ACTIVE_EXITING,
+        status=ValidatorStatus.PENDING_INITIALIZED,
         validator=source_validator_state,
     )
 
@@ -476,7 +476,7 @@ def test_exiting_source_consolidation(
     assert rejected_consolidation_alert is not None
 
 
-def test_exiting_target_consolidation(
+def test_invalid_target_consolidation_status(
     user_validator_1: TestValidator, user_validator_2: TestValidator, watcher: WatcherStub, withdrawal_address: str
 ):
     block = create_sample_block(
@@ -502,7 +502,7 @@ def test_exiting_target_consolidation(
     source_validator = Validator(
         index='1',
         balance='32000000000',
-        status=ValidatorStatus.ACTIVE_ONGOING,
+        status=ValidatorStatus.ACTIVE_EXITING,
         validator=source_validator_state,
     )
 
@@ -808,7 +808,7 @@ def test_rejected_consolidation(
     source_validator = Validator(
         index='1',
         balance='32000000000',
-        status=ValidatorStatus.ACTIVE_EXITING,
+        status=ValidatorStatus.PENDING_INITIALIZED,
         validator=source_validator_state,
     )
 
@@ -902,7 +902,7 @@ def no_rejected_consolidation_alert_for_accepted_consolidations(
     source_validator = Validator(
         index='1',
         balance='32000000000',
-        status=ValidatorStatus.ACTIVE_ONGOING,
+        status=ValidatorStatus.ACTIVE_EXITING,
         validator=source_validator_state,
     )
 
@@ -985,7 +985,7 @@ def test_consolidation_for_source_requested_to_exit_by_vebo(
     source_validator = Validator(
         index='1',
         balance='32000000000',
-        status=ValidatorStatus.ACTIVE_ONGOING,
+        status=ValidatorStatus.ACTIVE_EXITING,
         validator=source_validator_state,
     )
 
@@ -1080,7 +1080,7 @@ def test_consolidation_for_target_requested_to_exit_by_vebo(
     source_validator = Validator(
         index='1',
         balance='32000000000',
-        status=ValidatorStatus.ACTIVE_ONGOING,
+        status=ValidatorStatus.ACTIVE_EXITING,
         validator=source_validator_state,
     )
 


### PR DESCRIPTION
Previously, the invalid consolidation status alert was incorrectly triggered if the status of the consolidating validator was `active_exiting`. Now the `active_exiting` is the only valid status of consolidating validators. Now, if consolidating validators have statuses other than `active_exiting`, the alert about the invalid status of consolidating validators is triggered.