### PR TITLE
chore: increase threshold for over-consolidation alert

### DIFF
--- a/src/handlers/consolidation.py
+++ b/src/handlers/consolidation.py
@@ -135,7 +135,7 @@ class ConsolidationHandler(WatcherHandler):
             if target_validator is None:
                 raise ValueError(f'Unknown target validator pubkey: {consolidation.target_pubkey}')
 
-            if int(source_validator.balance) + int(target_validator.balance) > 2048000000000:
+            if int(source_validator.balance) + int(target_validator.balance) > 2049000000000:
                 over_deposit_consolidations.append(
                     OverDepositConsolidation(
                         source_address=consolidation.source_address,
@@ -247,7 +247,7 @@ class ConsolidationHandler(WatcherHandler):
 
     def _send_over_deposit(self, watcher, slot: str, consolidations: list[OverDepositConsolidation]):
         alert = CommonAlert(name="HeadWatcherConsolidationOverDeposit", severity="critical")
-        summary = "⚠️⚠️⚠️ Total balance of source and target validators during consolidation is greater than 2048 ETH"
+        summary = "⚠️⚠️⚠️ Total balance of source and target validators during consolidation is greater than 2049 ETH"
         description = '\n\n'.join(
             self._describe_over_deposit_consolidation(c, watcher.user_keys) for c in consolidations
         )

--- a/tests/execution_requests/test_consolidations.py
+++ b/tests/execution_requests/test_consolidations.py
@@ -293,7 +293,7 @@ def test_over_deposit_consolidation(
     )
     source_validator = Validator(
         index='1',
-        balance='1024000000001',
+        balance='1025000000001',
         status=ValidatorStatus.ACTIVE_EXITING,
         validator=source_validator_state,
     )
@@ -352,7 +352,7 @@ def test_over_deposit_consolidation(
     assert over_deposit_consolidation_alert.labels.severity == 'critical'
     assert (
         over_deposit_consolidation_alert.annotations.summary
-        == "⚠️⚠️⚠️ Total balance of source and target validators during consolidation is greater than 2048 ETH"
+        == "⚠️⚠️⚠️ Total balance of source and target validators during consolidation is greater than 2049 ETH"
     )
     assert withdrawal_address in over_deposit_consolidation_alert.annotations.description
     assert source_validator.index in over_deposit_consolidation_alert.annotations.description


### PR DESCRIPTION
Increase the threshold for the over-consolidation alert. Previously, this alert was triggered when the balance of the target consolidation validator was greater than 2048 ETH. Now it is triggered only when the balance of the target of consolidation is greater than 2049 ETH.