### PR TITLE
fix: replace slot number with state root

### DIFF
--- a/src/handlers/consolidation.py
+++ b/src/handlers/consolidation.py
@@ -114,9 +114,10 @@ class ConsolidationHandler(WatcherHandler):
         self, watcher, block: FullBlockInfo, consolidations: list[ConsolidationRequest]
     ):
         slot = block.message.slot
+        state_root = block.message.state_root
         pubkeys = list({pk for c in consolidations for pk in (c.source_pubkey, c.target_pubkey)})
-        validators = watcher.consensus.get_validators(slot, pubkeys)
-        pending_consolidations = watcher.consensus.get_pending_consolidations(slot)
+        validators = watcher.consensus.get_validators(state_root, pubkeys)
+        pending_consolidations = watcher.consensus.get_pending_consolidations(state_root)
         self._update_last_requested_exit_indexes(watcher, block)
 
         all_exit_indexes = set().union(*self.last_requested_exit_indexes.values())


### PR DESCRIPTION
In the previous version of the app, endpoints for getting extended information about validators and pending consolidations were called by a slot number. In rare cases, it might lead to a race condition when, after a new head appeared on CL, a Beacon node didn't have time to finish a state transition, and when the app called endpoints to get validators and pending consolidations, a Beacon node returned "empty" data for the head slot where info from the block is not included. It may lead to false-positive alerts.

Now, information about validators and pending consolidations is requested by the state root instead of a slot number. With this approach, a Beacon node should never return "empty" data for head slots. When information in slots is requested using the state root, a Beacon node must always return the "final" state of the requested slot.