### PR TITLE
feat: add configurable handler selection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 DRY_RUN=False
 LOG_LEVEL=INFO
+# Optional comma-separated list. Defaults to all handlers when unset.
+# ENABLED_HANDLERS=slashing,exits,consolidation,el_triggered_exit
 
 # For option when KEYS_SOURCE is 'keys_api'
 CONSENSUS_CLIENT_URI=URL_TO_CL_API

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Currently it supports:
 * **Required:** false
 * **Default:** false
 ---
+`ENABLED_HANDLERS` - Comma-separated list of configurable handlers enabled for this instance. Available handlers: `slashing`, `exits`, `consolidation`, `el_triggered_exit`. Chain reorganization monitoring is always enabled
+* **Required:** false
+* **Default:** all available handlers
+---
 `KEYS_SOURCE` - Keys source. If `keys_api` - application will fetch keys from Keys API, if `file` - application will fetch keys from `KEYS_FILE_PATH`
 * **Required:** false
 * **Default:** keys_api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - LOG_LEVEL=${LOG_LEVEL}
       - DRY_RUN=${DRY_RUN}
       - DISABLE_UNEXPECTED_EXIT_ALERTS=${DISABLE_UNEXPECTED_EXIT_ALERTS}
+      - ENABLED_HANDLERS=${ENABLED_HANDLERS}
 
   prometheus:
     image: prom/prometheus:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - LOG_LEVEL=${LOG_LEVEL}
       - DRY_RUN=${DRY_RUN}
       - DISABLE_UNEXPECTED_EXIT_ALERTS=${DISABLE_UNEXPECTED_EXIT_ALERTS}
-      - ENABLED_HANDLERS=${ENABLED_HANDLERS}
+      - ENABLED_HANDLERS
 
   prometheus:
     image: prom/prometheus:latest

--- a/src/main.py
+++ b/src/main.py
@@ -32,6 +32,8 @@ CONFIGURABLE_HANDLER_TYPES: dict[str, type[WatcherHandler]] = {
 
 def build_handlers(enabled_handlers: list[str] | None = None) -> list[WatcherHandler]:
     handler_names = list(CONFIGURABLE_HANDLER_TYPES) if enabled_handlers is None else enabled_handlers
+    if not handler_names:
+        raise ValueError('ENABLED_HANDLERS must contain at least one handler name')
 
     duplicate_handlers = sorted({name for name in handler_names if handler_names.count(name) > 1})
     if duplicate_handlers:
@@ -51,7 +53,7 @@ def build_handlers(enabled_handlers: list[str] | None = None) -> list[WatcherHan
 
 
 def main():
-    handlers = build_handlers(variables.ENABLED_HANDLERS)
+    handlers = build_handlers(variables.parse_enabled_handlers(variables.ENABLED_HANDLERS))
 
     BUILD_INFO.info(get_build_info())
 

--- a/src/main.py
+++ b/src/main.py
@@ -6,6 +6,7 @@ from src.handlers.consolidation import ConsolidationHandler
 from src.handlers.el_triggered_exit import ElTriggeredExitHandler
 from src.handlers.exit import ExitsHandler
 from src.handlers.fork import ForkHandler
+from src.handlers.handler import WatcherHandler
 from src.handlers.slashing import SlashingHandler
 from src.keys_source.base_source import SourceType
 from src.keys_source.file_source import FileSource
@@ -21,8 +22,37 @@ from src.web3py.typings import Web3
 
 logger = logging.getLogger()
 
+CONFIGURABLE_HANDLER_TYPES: dict[str, type[WatcherHandler]] = {
+    'slashing': SlashingHandler,
+    'exits': ExitsHandler,
+    'consolidation': ConsolidationHandler,
+    'el_triggered_exit': ElTriggeredExitHandler,
+}
+
+
+def build_handlers(enabled_handlers: list[str] | None = None) -> list[WatcherHandler]:
+    handler_names = list(CONFIGURABLE_HANDLER_TYPES) if enabled_handlers is None else enabled_handlers
+
+    duplicate_handlers = sorted({name for name in handler_names if handler_names.count(name) > 1})
+    if duplicate_handlers:
+        raise ValueError(f'Duplicate handlers in ENABLED_HANDLERS: {", ".join(duplicate_handlers)}')
+
+    unknown_handlers = sorted(set(handler_names) - CONFIGURABLE_HANDLER_TYPES.keys())
+    if unknown_handlers:
+        available_handlers = ', '.join(CONFIGURABLE_HANDLER_TYPES)
+        raise ValueError(
+            f'Unknown handlers in ENABLED_HANDLERS: {", ".join(unknown_handlers)}. '
+            f'Available handlers: {available_handlers}'
+        )
+
+    handlers: list[WatcherHandler] = [ForkHandler()]
+    handlers.extend(CONFIGURABLE_HANDLER_TYPES[name]() for name in handler_names)
+    return handlers
+
 
 def main():
+    handlers = build_handlers(variables.ENABLED_HANDLERS)
+
     BUILD_INFO.info(get_build_info())
 
     logger.info({'msg': 'Ethereum head watcher startup.'})
@@ -57,14 +87,6 @@ def main():
     if variables.DRY_RUN:
         logger.warning({'msg': 'Dry run mode enabled! No alerts will be sent.'})
 
-    handlers = [
-        SlashingHandler(),
-        ForkHandler(),
-        ExitsHandler(),
-        # FinalityHandler(), ???
-        ConsolidationHandler(),
-        ElTriggeredExitHandler(),
-    ]
     Watcher(handlers, keys_source, web3).run()
 
 

--- a/src/variables.py
+++ b/src/variables.py
@@ -1,6 +1,17 @@
 import json
 import os
 
+
+def parse_enabled_handlers(value: str | None) -> list[str] | None:
+    """Parse handler names, using ``None`` to represent the default handler set."""
+    if value is None or not value.strip():
+        return None
+    handlers = [handler.strip() for handler in value.split(',') if handler.strip()]
+    if not handlers:
+        raise ValueError('ENABLED_HANDLERS must contain at least one handler name')
+    return handlers
+
+
 LOG_LEVEL = os.getenv('LOG_LEVEL', 'INFO')
 
 # - Providers-
@@ -48,6 +59,8 @@ LIDO_CONSOLIDATION_BUS_ADDRESS = os.getenv('LIDO_CONSOLIDATION_BUS_ADDRESS', '')
 VALID_WITHDRAWAL_ADDRESSES = [x.lower() for x in os.getenv('VALID_WITHDRAWAL_ADDRESSES', '').split(',') if x]
 
 DISABLE_UNEXPECTED_EXIT_ALERTS = [x.strip() for x in os.getenv('DISABLE_UNEXPECTED_EXIT_ALERTS', '').split(',') if x]
+
+ENABLED_HANDLERS = parse_enabled_handlers(os.getenv('ENABLED_HANDLERS'))
 
 # - Metrics -
 PROMETHEUS_PORT = int(os.getenv('PROMETHEUS_PORT', 9000))

--- a/src/variables.py
+++ b/src/variables.py
@@ -4,7 +4,7 @@ import os
 
 def parse_enabled_handlers(value: str | None) -> list[str] | None:
     """Parse handler names, using ``None`` to represent the default handler set."""
-    if value is None or not value.strip():
+    if value is None:
         return None
     handlers = [handler.strip() for handler in value.split(',') if handler.strip()]
     if not handlers:
@@ -60,7 +60,7 @@ VALID_WITHDRAWAL_ADDRESSES = [x.lower() for x in os.getenv('VALID_WITHDRAWAL_ADD
 
 DISABLE_UNEXPECTED_EXIT_ALERTS = [x.strip() for x in os.getenv('DISABLE_UNEXPECTED_EXIT_ALERTS', '').split(',') if x]
 
-ENABLED_HANDLERS = parse_enabled_handlers(os.getenv('ENABLED_HANDLERS'))
+ENABLED_HANDLERS = os.getenv('ENABLED_HANDLERS')
 
 # - Metrics -
 PROMETHEUS_PORT = int(os.getenv('PROMETHEUS_PORT', 9000))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,68 @@
+import pytest
+
+from src.handlers.consolidation import ConsolidationHandler
+from src.handlers.el_triggered_exit import ElTriggeredExitHandler
+from src.handlers.exit import ExitsHandler
+from src.handlers.fork import ForkHandler
+from src.handlers.slashing import SlashingHandler
+from src.main import build_handlers
+from src.variables import parse_enabled_handlers
+
+
+@pytest.mark.parametrize(
+    ('value', 'expected'),
+    [
+        (None, None),
+        ('', None),
+        ('  ', None),
+        ('fork', ['fork']),
+        (' slashing, exits ', ['slashing', 'exits']),
+    ],
+)
+def test_parse_enabled_handlers(value, expected):
+    assert parse_enabled_handlers(value) == expected
+
+
+@pytest.mark.parametrize('value', [',', ', ,'])
+def test_parse_enabled_handlers_rejects_lists_without_names(value):
+    with pytest.raises(ValueError, match='ENABLED_HANDLERS must contain at least one handler name'):
+        parse_enabled_handlers(value)
+
+
+def test_build_handlers_defaults_to_all_handlers():
+    handlers = build_handlers()
+
+    assert [type(handler) for handler in handlers] == [
+        ForkHandler,
+        SlashingHandler,
+        ExitsHandler,
+        ConsolidationHandler,
+        ElTriggeredExitHandler,
+    ]
+
+
+def test_build_handlers_uses_selected_handlers_and_mandatory_fork_handler():
+    handlers = build_handlers(['exits'])
+
+    assert [type(handler) for handler in handlers] == [ForkHandler, ExitsHandler]
+
+
+def test_build_handlers_keeps_fork_handler_when_no_configurable_handlers_are_selected():
+    handlers = build_handlers([])
+
+    assert [type(handler) for handler in handlers] == [ForkHandler]
+
+
+def test_build_handlers_rejects_unknown_handler():
+    with pytest.raises(ValueError, match='Unknown handlers in ENABLED_HANDLERS: finality'):
+        build_handlers(['finality'])
+
+
+def test_build_handlers_rejects_configuring_mandatory_fork_handler():
+    with pytest.raises(ValueError, match='Unknown handlers in ENABLED_HANDLERS: fork'):
+        build_handlers(['fork'])
+
+
+def test_build_handlers_rejects_duplicate_handler():
+    with pytest.raises(ValueError, match='Duplicate handlers in ENABLED_HANDLERS: exits'):
+        build_handlers(['exits', 'exits'])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,8 +13,6 @@ from src.variables import parse_enabled_handlers
     ('value', 'expected'),
     [
         (None, None),
-        ('', None),
-        ('  ', None),
         ('fork', ['fork']),
         (' slashing, exits ', ['slashing', 'exits']),
     ],
@@ -23,7 +21,7 @@ def test_parse_enabled_handlers(value, expected):
     assert parse_enabled_handlers(value) == expected
 
 
-@pytest.mark.parametrize('value', [',', ', ,'])
+@pytest.mark.parametrize('value', ['', '  ', ',', ', ,'])
 def test_parse_enabled_handlers_rejects_lists_without_names(value):
     with pytest.raises(ValueError, match='ENABLED_HANDLERS must contain at least one handler name'):
         parse_enabled_handlers(value)
@@ -47,10 +45,9 @@ def test_build_handlers_uses_selected_handlers_and_mandatory_fork_handler():
     assert [type(handler) for handler in handlers] == [ForkHandler, ExitsHandler]
 
 
-def test_build_handlers_keeps_fork_handler_when_no_configurable_handlers_are_selected():
-    handlers = build_handlers([])
-
-    assert [type(handler) for handler in handlers] == [ForkHandler]
+def test_build_handlers_rejects_empty_handler_list():
+    with pytest.raises(ValueError, match='ENABLED_HANDLERS must contain at least one handler name'):
+        build_handlers([])
 
 
 def test_build_handlers_rejects_unknown_handler():


### PR DESCRIPTION
Adds ENABLED_HANDLERS for per-instance handler selection.

- Keeps reorg monitoring always enabled
- Validates unknown, duplicate, and
    malformed handler lists
- Adds configuration documentation and tests